### PR TITLE
Add link to new repo in readme

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,7 @@
+This repo is no longer maintained. Please see here: https://git.launchpad.net/rubber/
+
+-------------------------------------------------------------------------------------
+
 This is Rubber.
 
 Rubber is a building system for LaTeX documents. It is based on a routine that


### PR DESCRIPTION
Took me a while to realise that the main repo is elsewhere — I was having the same issue as #1, and this repo comes up higher on Google search results when searching for rubber. I figured if it's going to stick around, it's worthwhile to put a notice in the readme for future travellers.